### PR TITLE
Switch to using our standard PHP 7.4 docker image for tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "2"
 services:
 
   php:
-    image: silintl/php7-apache:7.4.19
+    image: silintl/php7:7.4
     volumes:
       - ./:/data
     extra_hosts:


### PR DESCRIPTION
### Fixed
- Switch to using our standard PHP 7.4 docker image for tests

---

This part of our move to stop using (and archive) our `silintl/php7-apache` Docker image.